### PR TITLE
Removida linha para copia do vendor

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,7 +15,7 @@ COPY database ./database
 COPY public ./public
 COPY resources ./resources
 COPY routes ./routes
-COPY vendor ./vendor
+
 COPY scripts/update_laravel.sh ./scripts/
 COPY docker/entrypoint.sh /caronae-entrypoint.sh
 


### PR DESCRIPTION
Removida a linha do copy da pasta vendor por na hora da criação da container ainda não existir a pasta no projeto causando assim erro.