### PR TITLE
Envio de emails com Amazon SES e refactor do Falaê

### DIFF
--- a/app/Http/Controllers/API/V1/FalaeController.php
+++ b/app/Http/Controllers/API/V1/FalaeController.php
@@ -3,6 +3,7 @@
 namespace Caronae\Http\Controllers\API\v1;
 
 use Caronae\Http\Controllers\BaseController;
+use Caronae\Mail\FalaeMessage;
 use Illuminate\Http\Request;
 use Log;
 use Mail;
@@ -13,16 +14,12 @@ class FalaeController extends BaseController
     {
         $user = $request->user();
         $subject = $request->subject;
-        $body = $request->message . "\nID UFRJ: " . $user->id_ufrj;
+        $body = $request->message;
 
-        Log::info('Enviando mensagem através do Falaê', ['user_id' => $user->id, 'user_email' => $user->email, 'subject' => $subject, 'message' => $body]);
+        Log::info('Enviando mensagem através do Falaê', ['user_id' => $user->id, 'subject' => $subject]);
 
-        Mail::raw($body, function ($message) use ($user, $subject) {
-            $message->to('caronae@fundoverde.ufrj.br');
-            $message->replyTo($user->email, $user->name);
-            $message->subject($subject);
-        });
-        
+        Mail::send(new FalaeMessage($user, $subject, $body));
+
         return response()->json(['status' => 'Message sent.']);
     }
 }

--- a/app/Http/Controllers/API/V1/FalaeController.php
+++ b/app/Http/Controllers/API/V1/FalaeController.php
@@ -9,11 +9,6 @@ use Mail;
 
 class FalaeController extends BaseController
 {
-    public function __construct()
-    {
-        $this->middleware('api.v1.auth');
-    }
-
     public function sendMessage(Request $request)
     {
         $user = $request->user();

--- a/app/Mail/FalaeMessage.php
+++ b/app/Mail/FalaeMessage.php
@@ -14,19 +14,20 @@ class FalaeMessage extends Mailable implements ShouldQueue
 
     public $user;
     public $userMessage;
+    public $userSubject;
 
     public function __construct(User $user, $subject, $message)
     {
         $this->user = $user;
-        $this->subject = $subject;
+        $this->userSubject = $subject;
         $this->userMessage = $message;
     }
 
     public function build()
     {
         return $this->to('caronae@fundoverde.ufrj.br')
-                    ->from($this->user->email, $this->user->name)
                     ->replyTo($this->user->email)
+                    ->subject($this->userSubject)
                     ->text('emails.falae');
     }
 }

--- a/app/Mail/FalaeMessage.php
+++ b/app/Mail/FalaeMessage.php
@@ -14,20 +14,19 @@ class FalaeMessage extends Mailable implements ShouldQueue
 
     public $user;
     public $userMessage;
-    public $userSubject;
 
     public function __construct(User $user, $subject, $message)
     {
         $this->user = $user;
-        $this->userSubject = $subject;
         $this->userMessage = $message;
+
+        $this->to('caronae@fundoverde.ufrj.br');
+        $this->replyTo($this->user->email, $this->user->name);
+        $this->subject($subject);
     }
 
     public function build()
     {
-        return $this->to('caronae@fundoverde.ufrj.br')
-                    ->replyTo($this->user->email)
-                    ->subject($this->userSubject)
-                    ->text('emails.falae');
+        return $this->text('emails.falae');
     }
 }

--- a/app/Mail/FalaeMessage.php
+++ b/app/Mail/FalaeMessage.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Caronae\Mail;
+
+use Caronae\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+class FalaeMessage extends Mailable implements ShouldQueue
+{
+    use Queueable, SerializesModels;
+
+    public $user;
+    public $userMessage;
+
+    public function __construct(User $user, $subject, $message)
+    {
+        $this->user = $user;
+        $this->subject = $subject;
+        $this->userMessage = $message;
+    }
+
+    public function build()
+    {
+        return $this->to('caronae@fundoverde.ufrj.br')
+                    ->from($this->user->email, $this->user->name)
+                    ->replyTo($this->user->email)
+                    ->text('emails.falae');
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "type": "project",
     "require": {
         "php": ">=7.1.0",
+        "aws/aws-sdk-php": "^3.67",
         "backpack/base": "^0.9.0",
         "backpack/crud": "^3.4.0",
         "barryvdh/laravel-ide-helper": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "9a34fcf477025b83e2df11fc2d9ea5fa",
+    "content-hash": "b2854dcdb2840c364256b7a9683c1385",
     "packages": [
         {
             "name": "almasaeed2010/adminlte",
@@ -51,16 +51,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.67.4",
+            "version": "3.67.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "df94a9ad78c9e817a9887bedf0e5b269c4f25810"
+                "reference": "701152ff155ad7ea3fe64d264a0fbf4e26f4e3a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/df94a9ad78c9e817a9887bedf0e5b269c4f25810",
-                "reference": "df94a9ad78c9e817a9887bedf0e5b269c4f25810",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/701152ff155ad7ea3fe64d264a0fbf4e26f4e3a4",
+                "reference": "701152ff155ad7ea3fe64d264a0fbf4e26f4e3a4",
                 "shasum": ""
             },
             "require": {
@@ -127,7 +127,7 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2018-08-31T21:53:42+00:00"
+            "time": "2018-09-27T19:41:06+00:00"
         },
         {
             "name": "backpack/base",

--- a/config/failed-job-monitor.php
+++ b/config/failed-job-monitor.php
@@ -24,10 +24,10 @@ return [
     /*
      * The channels to which the notification will be sent.
      */
-    'channels' => ['mail', 'slack'],
+    'channels' => ['slack'],
 
     'mail' => [
-        'to' => 'macecchi@gmail.com',
+        'to' => '',
     ],
 
     'slack' => [

--- a/config/mail.php
+++ b/config/mail.php
@@ -4,11 +4,11 @@ return [
 
     'driver' => env('MAIL_DRIVER', 'smtp'),
 
-    'host' => env('MAIL_HOST', 'smtp.mailgun.org'),
-    'port' => env('MAIL_PORT', 587),
+    'host' => env('MAIL_HOST', 'smtp.mailtrap.io'),
+    'port' => env('MAIL_PORT', 2525),
 
     'from' => [
-        'address' => env('MAIL_FROM_ADDRESS', 'caronae@fundoverde.ufrj.br'),
+        'address' => env('MAIL_FROM_ADDRESS', 'no-reply@caronae.org'),
         'name' => env('MAIL_FROM_NAME', 'Caronaê'),
     ],
 

--- a/config/mail.php
+++ b/config/mail.php
@@ -2,119 +2,24 @@
 
 return [
 
-    /*
-    |--------------------------------------------------------------------------
-    | Mail Driver
-    |--------------------------------------------------------------------------
-    |
-    | Laravel supports both SMTP and PHP's "mail" function as drivers for the
-    | sending of e-mail. You may specify which one you're using throughout
-    | your application here. By default, Laravel is setup for SMTP mail.
-    |
-    | Supported: "smtp", "sendmail", "mailgun", "mandrill", "ses",
-    |            "sparkpost", "log", "array"
-    |
-    */
-
     'driver' => env('MAIL_DRIVER', 'smtp'),
 
-    /*
-    |--------------------------------------------------------------------------
-    | SMTP Host Address
-    |--------------------------------------------------------------------------
-    |
-    | Here you may provide the host address of the SMTP server used by your
-    | applications. A default option is provided that is compatible with
-    | the Mailgun mail service which will provide reliable deliveries.
-    |
-    */
-
     'host' => env('MAIL_HOST', 'smtp.mailgun.org'),
-
-    /*
-    |--------------------------------------------------------------------------
-    | SMTP Host Port
-    |--------------------------------------------------------------------------
-    |
-    | This is the SMTP port used by your application to deliver e-mails to
-    | users of the application. Like the host we have set this value to
-    | stay compatible with the Mailgun e-mail application by default.
-    |
-    */
-
     'port' => env('MAIL_PORT', 587),
-
-    /*
-    |--------------------------------------------------------------------------
-    | Global "From" Address
-    |--------------------------------------------------------------------------
-    |
-    | You may wish for all e-mails sent by your application to be sent from
-    | the same address. Here, you may specify a name and address that is
-    | used globally for all e-mails that are sent by your application.
-    |
-    */
 
     'from' => [
         'address' => env('MAIL_FROM_ADDRESS', 'caronae@fundoverde.ufrj.br'),
         'name' => env('MAIL_FROM_NAME', 'Caronaê'),
     ],
 
-    /*
-    |--------------------------------------------------------------------------
-    | E-Mail Encryption Protocol
-    |--------------------------------------------------------------------------
-    |
-    | Here you may specify the encryption protocol that should be used when
-    | the application send e-mail messages. A sensible default using the
-    | transport layer security protocol should provide great security.
-    |
-    */
-
     'encryption' => env('MAIL_ENCRYPTION', 'tls'),
-
-    /*
-    |--------------------------------------------------------------------------
-    | SMTP Server Username
-    |--------------------------------------------------------------------------
-    |
-    | If your SMTP server requires a username for authentication, you should
-    | set it here. This will get used to authenticate with your server on
-    | connection. You may also set the "password" value below this one.
-    |
-    */
-
     'username' => env('MAIL_USERNAME'),
-
     'password' => env('MAIL_PASSWORD'),
-
-    /*
-    |--------------------------------------------------------------------------
-    | Sendmail System Path
-    |--------------------------------------------------------------------------
-    |
-    | When using the "sendmail" driver to send e-mails, we will need to know
-    | the path to where Sendmail lives on this server. A default path has
-    | been provided here, which will work well on most of your systems.
-    |
-    */
 
     'sendmail' => '/usr/sbin/sendmail -bs',
 
-    /*
-    |--------------------------------------------------------------------------
-    | Markdown Mail Settings
-    |--------------------------------------------------------------------------
-    |
-    | If you are using Markdown based email rendering, you may configure your
-    | theme and component paths here, allowing you to customize the design
-    | of the emails. Or, you may simply stick with the Laravel defaults!
-    |
-    */
-
     'markdown' => [
         'theme' => 'default',
-
         'paths' => [
             resource_path('views/vendor/mail'),
         ],

--- a/config/queue.php
+++ b/config/queue.php
@@ -78,7 +78,7 @@ return [
     */
 
     'failed' => [
-        'database' => env('DB_CONNECTION', 'mysql'),
+        'database' => env('DB_CONNECTION', 'pgsql'),
         'table' => 'failed_jobs',
     ],
 

--- a/config/services.php
+++ b/config/services.php
@@ -2,18 +2,6 @@
 
 return [
 
-    /*
-    |--------------------------------------------------------------------------
-    | Third Party Services
-    |--------------------------------------------------------------------------
-    |
-    | This file is for storing the credentials for third party services such
-    | as Stripe, Mailgun, SparkPost and others. This file provides a sane
-    | default location for this type of information, allowing packages
-    | to have a conventional place to find your various credentials.
-    |
-    */
-
     'mailgun' => [
         'domain' => env('MAILGUN_DOMAIN'),
         'secret' => env('MAILGUN_SECRET'),

--- a/resources/views/emails/falae.blade.php
+++ b/resources/views/emails/falae.blade.php
@@ -1,0 +1,4 @@
+{!! $userMessage !!}
+
+{!! $user->name !!}
+ID UFRJ: {!! $user->id_ufrj !!}

--- a/routes/api.v1.legacy.php
+++ b/routes/api.v1.legacy.php
@@ -44,6 +44,6 @@ Route::middleware('api.v1.auth')->group(function () {
     });
 
     Route::get('places', 'PlaceController@index');
+    Route::post('falae/sendMessage', 'FalaeController@sendMessage');
 });
 
-Route::post('falae/sendMessage', 'FalaeController@sendMessage');

--- a/routes/api.v1.php
+++ b/routes/api.v1.php
@@ -40,7 +40,5 @@ Route::middleware('api.v1.auth')->group(function () {
     });
 
     Route::get('places', 'PlaceController@index');
-
+    Route::post('falae/messages', 'FalaeController@sendMessage');
 });
-
-Route::post('falae/messages', 'FalaeController@sendMessage');

--- a/tests/controllers/API/v1/FalaeControllerTest.php
+++ b/tests/controllers/API/v1/FalaeControllerTest.php
@@ -4,11 +4,14 @@ namespace Caronae\Http\Controllers\API\V1;
 
 use Caronae\Mail\FalaeMessage;
 use Caronae\Models\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Illuminate\Support\Facades\Mail;
 use Tests\TestCase;
 
 class FalaeControllerTest extends TestCase
 {
+    use DatabaseTransactions;
+
     /** @test */
     public function should_send_email_to_team()
     {

--- a/tests/controllers/API/v1/FalaeControllerTest.php
+++ b/tests/controllers/API/v1/FalaeControllerTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Caronae\Http\Controllers\API\V1;
+
+use Caronae\Mail\FalaeMessage;
+use Caronae\Models\User;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+class FalaeControllerTest extends TestCase
+{
+    /** @test */
+    public function should_send_email_to_team()
+    {
+        Mail::fake();
+        $user = factory(User::class)->create();
+        $request = [
+            'subject' => '[Reclamação] Motorista não compareceu',
+            'message' => 'Combinei com o motorista e ele não compareceu no horário marcado.',
+        ];
+
+        $response = $this->jsonAs($user, 'POST', 'api/v1/falae/messages', $request);
+
+        $response->assertStatus(200);
+        $response->assertJson(['status' => 'Message sent.']);
+
+        Mail::assertQueued(FalaeMessage::class, function (FalaeMessage $mail) use ($user, $request) {
+            return $mail->hasTo('caronae@fundoverde.ufrj.br')
+                && $mail->hasReplyTo($user->email, $user->name)
+                && $mail->subject == $request['subject']
+                && $mail->userMessage == $request['message'];
+        });
+    }
+}


### PR DESCRIPTION
- Define Amazon SES como driver de email ao invés de SMTP
- Cria template de mensagem do Falaê usando Mailables do Laravel
- Adiciona teste para envio de mensagem do Falaê
- Move rotas do Falaê pra dentro do middleware de autenticação