### PR TITLE
Change seed sequence to keep admin user on database

### DIFF
--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -8,9 +8,9 @@ class DatabaseSeeder extends Seeder
     {
         $this->call([
             NeighborhoodSeeder::class,
-            AdminTableSeeder::class,
             InstitutionSeeder::class,
             UserRideTableSeeder::class,
+            AdminTableSeeder::class,
         ]);
     }
 


### PR DESCRIPTION
Este PR modifica a sequencia em que os seeds acontecem, pois o seed da tabela admins acontecia antes do seed da tabela institutions e quando acontecia o truncate da tabela institutions o registro do administrador era apagado devido ao cascade. Trocando a sequência do seed o registro do administrador se mantém e assim se torna possível logar no sistema.